### PR TITLE
TEAM2-59 환경 활동 모집(GreenTeamPost) 관련 엔티티 및 위치 타입 정의

### DIFF
--- a/src/main/java/kr/bi/greenmate/common/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/bi/greenmate/common/domain/BaseTimeEntity.java
@@ -11,6 +11,6 @@ import lombok.Getter;
 public abstract class BaseTimeEntity extends CreatedOnlyEntity {
 
   @UpdateTimestamp
-  @Column(name = "updated_at", nullable = false)
+  @Column(nullable = false)
   protected LocalDateTime updatedAt;
 }

--- a/src/main/java/kr/bi/greenmate/common/domain/BaseTimeEntity.java
+++ b/src/main/java/kr/bi/greenmate/common/domain/BaseTimeEntity.java
@@ -1,0 +1,16 @@
+package kr.bi.greenmate.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseTimeEntity extends CreatedOnlyEntity {
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  protected LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/bi/greenmate/common/domain/CreatedOnlyEntity.java
+++ b/src/main/java/kr/bi/greenmate/common/domain/CreatedOnlyEntity.java
@@ -1,0 +1,16 @@
+package kr.bi.greenmate.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class CreatedOnlyEntity {
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  protected LocalDateTime createdAt;
+}

--- a/src/main/java/kr/bi/greenmate/common/domain/CreatedOnlyEntity.java
+++ b/src/main/java/kr/bi/greenmate/common/domain/CreatedOnlyEntity.java
@@ -11,6 +11,6 @@ import lombok.Getter;
 public abstract class CreatedOnlyEntity {
 
   @CreationTimestamp
-  @Column(name = "created_at", nullable = false, updatable = false)
+  @Column(nullable = false, updatable = false)
   protected LocalDateTime createdAt;
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -28,7 +28,6 @@ import kr.bi.greenmate.common.domain.BaseTimeEntity;
 import kr.bi.greenmate.user.domain.User;
 
 @Entity
-@Table(name = "green_team_post")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -43,10 +42,10 @@ public class GreenTeamPost extends BaseTimeEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @Column(name = "title", nullable = false, length = 50)
+  @Column(nullable = false, length = 50)
   private String title;
 
-  @Column(name = "content", nullable = false, length = 4000)
+  @Column(nullable = false, length = 4000)
   private String content;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -17,7 +17,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -39,19 +38,11 @@ import kr.bi.greenmate.user.domain.User;
 public class GreenTeamPost {
 
   @Id
-  @SequenceGenerator(
-      name = "greenTeamPostSeq",
-      sequenceName = "GREEN_TEAM_POST_SEQ",
-      allocationSize = 1
-  )
-  @GeneratedValue(
-      strategy = GenerationType.SEQUENCE,
-      generator = "greenTeamPostSeq"
-  )
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = true)
-  @JoinColumn(name = "user_id", nullable = true)
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @Column(nullable = false, length = 50)

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -19,14 +19,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import kr.bi.greenmate.common.domain.BaseTimeEntity;
 import kr.bi.greenmate.user.domain.User;
 
 @Entity
@@ -35,7 +33,7 @@ import kr.bi.greenmate.user.domain.User;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class GreenTeamPost {
+public class GreenTeamPost extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -79,14 +77,6 @@ public class GreenTeamPost {
 
   @Column(name = "deadline_at", nullable = false)
   private LocalDateTime deadlineAt;
-
-  @CreationTimestamp
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
-
-  @UpdateTimestamp
-  @Column(name = "updated_at", nullable = false)
-  private LocalDateTime updatedAt;
 
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<GreenTeamPostImage> images = new ArrayList<>();

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -1,0 +1,102 @@
+package kr.bi.greenmate.green_team_post.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import kr.bi.greenmate.user.domain.User;
+
+@Entity
+@Table(name = "green_team_post")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GreenTeamPost {
+
+  @Id
+  @SequenceGenerator(
+      name = "greenTeamPostSeq",
+      sequenceName = "GREEN_TEAM_POST_SEQ",
+      allocationSize = 1
+  )
+  @GeneratedValue(
+      strategy = GenerationType.SEQUENCE,
+      generator = "greenTeamPostSeq"
+  )
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = true)
+  @JoinColumn(name = "user_id", nullable = true)
+  private User user;
+
+  @Column(nullable = false, length = 50)
+  private String title;
+
+  @Column(nullable = false, length = 4000)
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "location_type", length = 10)
+  private LocationType locationType;
+
+  @Lob
+  @Column(name = "location_geojson")
+  private String locationGeojson;
+
+  @Column(name = "max_participants", nullable = false)
+  private Integer maxParticipants;
+
+  @Builder.Default
+  @Column(name = "participant_count", nullable = false)
+  private Integer participantCount = 0;
+
+  @Builder.Default
+  @Column(name = "like_count", nullable = false)
+  private Integer likeCount = 0;
+
+  @Builder.Default
+  @Column(name = "comment_count", nullable = false)
+  private Integer commentCount = 0;
+
+  @Column(name = "event_date", nullable = false)
+  private LocalDateTime eventDate;
+
+  @Column(name = "deadline_at", nullable = false)
+  private LocalDateTime deadlineAt;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<GreenTeamPostImage> images = new ArrayList<>();
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -43,18 +43,18 @@ public class GreenTeamPost extends BaseTimeEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @Column(nullable = false, length = 50)
+  @Column(name = "title", nullable = false, length = 50)
   private String title;
 
-  @Column(nullable = false, length = 4000)
+  @Column(name = "content", nullable = false, length = 4000)
   private String content;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "location_type", length = 10)
+  @Column(name = "location_type", nullable = false, length = 10)
   private LocationType locationType;
 
   @Lob
-  @Column(name = "location_geojson")
+  @Column(name = "location_geojson", nullable = false)
   private String locationGeojson;
 
   @Column(name = "max_participants", nullable = false)

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -17,7 +17,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,32 +48,32 @@ public class GreenTeamPost extends BaseTimeEntity {
   private String content;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "location_type", nullable = false, length = 10)
+  @Column(nullable = false, length = 10)
   private LocationType locationType;
 
   @Lob
-  @Column(name = "location_geojson", nullable = false)
+  @Column(nullable = false)
   private String locationGeojson;
 
-  @Column(name = "max_participants", nullable = false)
+  @Column(nullable = false)
   private Integer maxParticipants;
 
   @Builder.Default
-  @Column(name = "participant_count", nullable = false)
+  @Column(nullable = false)
   private Integer participantCount = 0;
 
   @Builder.Default
-  @Column(name = "like_count", nullable = false)
+  @Column(nullable = false)
   private Integer likeCount = 0;
 
   @Builder.Default
-  @Column(name = "comment_count", nullable = false)
+  @Column(nullable = false)
   private Integer commentCount = 0;
 
-  @Column(name = "event_date", nullable = false)
+  @Column(nullable = false)
   private LocalDateTime eventDate;
 
-  @Column(name = "deadline_at", nullable = false)
+  @Column(nullable = false)
   private LocalDateTime deadlineAt;
 
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
@@ -1,0 +1,53 @@
+package kr.bi.greenmate.green_team_post.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "green_team_post_image")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GreenTeamPostImage {
+
+  @Id
+  @SequenceGenerator(
+      name = "greenTeamPostImageSeq",
+      sequenceName = "GREEN_TEAM_POST_IMAGE_SEQ",
+      allocationSize = 1
+  )
+  @GeneratedValue(
+      strategy = GenerationType.SEQUENCE,
+      generator = "greenTeamPostImageSeq"
+  )
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "post_id", nullable = false)
+  private GreenTeamPost post;
+
+  @Column(name = "image_url", nullable = false, length = 64)
+  private String imageUrl;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +31,6 @@ public class GreenTeamPostImage extends CreatedOnlyEntity {
   @JoinColumn(name = "post_id", nullable = false)
   private GreenTeamPost post;
 
-  @Column(name = "image_url", nullable = false, length = 63)
+  @Column(nullable = false, length = 63)
   private String imageUrl;
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
@@ -1,7 +1,5 @@
 package kr.bi.greenmate.green_team_post.domain;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,12 +10,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.CreationTimestamp;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import kr.bi.greenmate.common.domain.CreatedOnlyEntity;
 
 @Entity
 @Table(name = "green_team_post_image")
@@ -25,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class GreenTeamPostImage {
+public class GreenTeamPostImage extends CreatedOnlyEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,8 +35,4 @@ public class GreenTeamPostImage {
 
   @Column(name = "image_url", nullable = false, length = 63)
   private String imageUrl;
-
-  @CreationTimestamp
-  @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
@@ -18,7 +18,6 @@ import lombok.NoArgsConstructor;
 import kr.bi.greenmate.common.domain.CreatedOnlyEntity;
 
 @Entity
-@Table(name = "green_team_post_image")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -29,7 +28,7 @@ public class GreenTeamPostImage extends CreatedOnlyEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "post_id", nullable = false)
   private GreenTeamPost post;
 

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPostImage.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -29,22 +28,14 @@ import lombok.NoArgsConstructor;
 public class GreenTeamPostImage {
 
   @Id
-  @SequenceGenerator(
-      name = "greenTeamPostImageSeq",
-      sequenceName = "GREEN_TEAM_POST_IMAGE_SEQ",
-      allocationSize = 1
-  )
-  @GeneratedValue(
-      strategy = GenerationType.SEQUENCE,
-      generator = "greenTeamPostImageSeq"
-  )
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "post_id", nullable = false)
   private GreenTeamPost post;
 
-  @Column(name = "image_url", nullable = false, length = 64)
+  @Column(name = "image_url", nullable = false, length = 63)
   private String imageUrl;
 
   @CreationTimestamp

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/LocationType.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/LocationType.java
@@ -1,0 +1,6 @@
+package kr.bi.greenmate.green_team_post.domain;
+
+public enum LocationType {
+    CIRCLE,
+    POLYGON
+}


### PR DESCRIPTION
### 개요
- [환경 활동 모집 DDL/Entity 구현](https://bi-2025-summer.atlassian.net/browse/TEAM2-59)

### 변경사항
- green_team_post 테이블의 GreenTeamPost 엔티티 구현
  - LocationType ENUM 정의
- green_team_post_image 테이블의 GreenTeamPostImage 엔티티 구현
- 공통 시간 필드를 위한 CreatedOnlyEntity, BaseTimeEntity 추상 클래스 구현

### 고민한 사항
- 디렉토리 구조 설계 방향: **기능별(도메인 중심) 분리 적용**
  : 디렉토리 구조를 **계층별 분리**(controller/service/repository) vs **기능별 분리**(도메인 중심) 중 어떤 방식으로 설계할지 검토
  - 결정: 기능(도메인) 중심의 디렉토리 분리 전략 적용
      - ex) `post/`, `user/`, `community/` 등 기능별 하위 디렉토리 구성
      - 각 기능 디렉토리 내부에 controller, service, repository, domain, dto 등 세분화
  - 근거:
      - 기능별(도메인 중심) 분리는 서버 스케일아웃 시 유리한 점을 고려함.

### 리뷰어에게 하고 싶은 말
- DB DDL 생성 작업은 Users 작업 완료 후 진행하겠습니다!