### PR TITLE
TEAM2-37 분리수거 학습 조회 API 구현

### DIFF
--- a/src/main/java/kr/bi/greenmate/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/kr/bi/greenmate/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,12 @@
+package kr.bi.greenmate.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/kr/bi/greenmate/common/repository/ObjectStorageRepository.java
+++ b/src/main/java/kr/bi/greenmate/common/repository/ObjectStorageRepository.java
@@ -1,4 +1,4 @@
-package kr.bi.greenmate.repository;
+package kr.bi.greenmate.common.repository;
 
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
@@ -2,6 +2,7 @@ package kr.bi.greenmate.recycling_edu_post.controller;
 
 import java.util.List;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,14 +10,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 import kr.bi.greenmate.recycling_edu_post.dto.RecyclingEduPostResponse;
 import kr.bi.greenmate.recycling_edu_post.service.RecyclingEduPostService;
-
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/v1/recycling-edu-posts")
 @Tag(name = "분리수거 학습 게시글 API", description = "분리수거 학습 게시글 조회 API")
 public class RecyclingEduPostController {
@@ -31,7 +34,9 @@ public class RecyclingEduPostController {
 
   @Operation(summary = "단일 게시글 조회", description = "특정 분리수거 학습 게시글을 조회합니다.")
   @GetMapping("/{id}")
-  public RecyclingEduPostResponse getPostById(@PathVariable Long id) {
+  public RecyclingEduPostResponse getPostById(
+      @PathVariable @NotNull @Min(1) Long id
+  ) {
     return service.getPostById(id);
   }
 }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
@@ -1,0 +1,41 @@
+package kr.bi.greenmate.recycling_edu_post.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import kr.bi.greenmate.recycling_edu_post.dto.RecyclingEduPostResponse;
+import kr.bi.greenmate.recycling_edu_post.service.RecyclingEduPostService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recycling-edu-posts")
+@Tag(name = "분리수거 학습 게시글 API", description = "분리수거 학습 게시글 조회 API")
+public class RecyclingEduPostController {
+
+  private final RecyclingEduPostService service;
+
+  @Operation(summary = "전체 목록 조회", description = "분리수거 학습 게시글 목록을 조회합니다.")
+  @GetMapping
+  @ResponseStatus(HttpStatus.OK)
+  public List<RecyclingEduPostResponse> getAllPosts() {
+    return service.getAllPosts();
+  }
+
+  @Operation(summary = "단일 게시글 조회", description = "특정 분리수거 학습 게시글을 조회합니다.")
+  @GetMapping("/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  public RecyclingEduPostResponse getPostById(@PathVariable Long id) {
+    return service.getPostById(id);
+  }
+}

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
@@ -2,11 +2,9 @@ package kr.bi.greenmate.recycling_edu_post.controller;
 
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/recycling-edu-posts")
+@RequestMapping("/api/v1/recycling-edu-posts")
 @Tag(name = "분리수거 학습 게시글 API", description = "분리수거 학습 게시글 조회 API")
 public class RecyclingEduPostController {
 
@@ -27,14 +25,12 @@ public class RecyclingEduPostController {
 
   @Operation(summary = "전체 목록 조회", description = "분리수거 학습 게시글 목록을 조회합니다.")
   @GetMapping
-  @ResponseStatus(HttpStatus.OK)
   public List<RecyclingEduPostResponse> getAllPosts() {
     return service.getAllPosts();
   }
 
   @Operation(summary = "단일 게시글 조회", description = "특정 분리수거 학습 게시글을 조회합니다.")
   @GetMapping("/{id}")
-  @ResponseStatus(HttpStatus.OK)
   public RecyclingEduPostResponse getPostById(@PathVariable Long id) {
     return service.getPostById(id);
   }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
-import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
 
 @Getter
@@ -29,13 +28,12 @@ public class RecyclingEduPostResponse {
   @Schema(description = "게시글 생성일시", example = "2025-08-07T10:00:00")
   private final LocalDateTime createdAt;
 
-  public static RecyclingEduPostResponse from(RecyclingEduPost post,
-      ObjectStorageRepository objectStorageRepository) {
+  public static RecyclingEduPostResponse from(RecyclingEduPost post, String imageUrl) {
     return RecyclingEduPostResponse.builder()
         .id(post.getId())
         .title(post.getTitle())
         .content(post.getContent())
-        .imageUrl(objectStorageRepository.getDownloadUrl(post.getImageUrl()))
+        .imageUrl(imageUrl)
         .createdAt(post.getCreatedAt())
         .build();
   }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
@@ -1,0 +1,40 @@
+package kr.bi.greenmate.recycling_edu_post.dto;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
+
+@Getter
+@Builder
+@Schema(description = "분리수거 학습 게시글 응답 DTO")
+public class RecyclingEduPostResponse {
+
+  @Schema(description = "게시글 ID", example = "1")
+  private final Long id;
+
+  @Schema(description = "게시글 제목", example = "페트병 분리수거 방법")
+  private final String title;
+
+  @Schema(description = "게시글 본문 내용", example = "페트병은 라벨을 제거하고 깨끗이 헹군 후 배출해야 합니다.")
+  private final String content;
+
+  @Schema(description = "대표 이미지 URL", example = "https://greenmate.kr/images/recycling1.jpg")
+  private final String imageUrl;
+
+  @Schema(description = "게시글 생성일시", example = "2025-08-07T10:00:00")
+  private final LocalDateTime createdAt;
+
+  public static RecyclingEduPostResponse from(RecyclingEduPost post) {
+    return RecyclingEduPostResponse.builder()
+        .id(post.getId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .imageUrl(post.getImageUrl())
+        .createdAt(post.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/dto/RecyclingEduPostResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
+import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
 
 @Getter
@@ -28,12 +29,13 @@ public class RecyclingEduPostResponse {
   @Schema(description = "게시글 생성일시", example = "2025-08-07T10:00:00")
   private final LocalDateTime createdAt;
 
-  public static RecyclingEduPostResponse from(RecyclingEduPost post) {
+  public static RecyclingEduPostResponse from(RecyclingEduPost post,
+      ObjectStorageRepository objectStorageRepository) {
     return RecyclingEduPostResponse.builder()
         .id(post.getId())
         .title(post.getTitle())
         .content(post.getContent())
-        .imageUrl(post.getImageUrl())
+        .imageUrl(objectStorageRepository.getDownloadUrl(post.getImageUrl()))
         .createdAt(post.getCreatedAt())
         .build();
   }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/repository/RecyclingEduPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/repository/RecyclingEduPostRepository.java
@@ -1,0 +1,8 @@
+package kr.bi.greenmate.recycling_edu_post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
+
+public interface RecyclingEduPostRepository extends JpaRepository<RecyclingEduPost, Long> {
+}

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -2,11 +2,10 @@ package kr.bi.greenmate.recycling_edu_post.service;
 
 import java.util.List;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
+import kr.bi.greenmate.common.exception.ResourceNotFoundException;
 import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
 import kr.bi.greenmate.recycling_edu_post.dto.RecyclingEduPostResponse;
@@ -38,8 +37,8 @@ public class RecyclingEduPostService {
    */
   public RecyclingEduPostResponse getPostById(Long id) {
     RecyclingEduPost post = repository.findById(id)
-        .orElseThrow(() -> new ResponseStatusException(
-            HttpStatus.NOT_FOUND, "해당 분리수거 학습글이 존재하지 않습니다."));
+        .orElseThrow(() ->
+            new ResourceNotFoundException("해당 분리수거 학습글이 존재하지 않습니다."));
 
     String imageUrl = objectStorageRepository.getDownloadUrl(post.getImageUrl());
     return RecyclingEduPostResponse.from(post, imageUrl);

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -12,7 +12,6 @@ import kr.bi.greenmate.recycling_edu_post.repository.RecyclingEduPostRepository;
 
 import lombok.RequiredArgsConstructor;
 
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,9 +25,11 @@ public class RecyclingEduPostService {
    */
   public List<RecyclingEduPostResponse> getAllPosts() {
     List<RecyclingEduPost> posts = repository.findAll();
-
     return posts.stream()
-        .map(post -> RecyclingEduPostResponse.from(post, objectStorageRepository))
+        .map(post -> RecyclingEduPostResponse.from(
+            post,
+            objectStorageRepository.getDownloadUrl(post.getImageUrl())
+        ))
         .toList();
   }
 
@@ -39,10 +40,9 @@ public class RecyclingEduPostService {
     if (id == null) {
       throw new IllegalArgumentException("ID는 null일 수 없습니다.");
     }
-
     RecyclingEduPost post = repository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("해당 분리수거 학습글이 존재하지 않습니다."));
-
-    return RecyclingEduPostResponse.from(post, objectStorageRepository);
+    String imageUrl = objectStorageRepository.getDownloadUrl(post.getImageUrl());
+    return RecyclingEduPostResponse.from(post, imageUrl);
   }
 }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -1,0 +1,45 @@
+package kr.bi.greenmate.recycling_edu_post.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
+import kr.bi.greenmate.recycling_edu_post.dto.RecyclingEduPostResponse;
+import kr.bi.greenmate.recycling_edu_post.repository.RecyclingEduPostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecyclingEduPostService {
+
+  private final RecyclingEduPostRepository repository;
+
+  /**
+   * 전체 목록 조회
+   */
+  public List<RecyclingEduPostResponse> getAllPosts() {
+    return repository.findAll().stream()
+        .map(RecyclingEduPostResponse::from)
+        .toList();
+  }
+
+  /**
+   * 단일 조회
+   */
+  public RecyclingEduPostResponse getPostById(Long id) {
+    if (id == null) {
+      throw new IllegalArgumentException("ID는 null일 수 없습니다.");
+    }
+
+    RecyclingEduPost post = repository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 분리수거 학습글이 존재하지 않습니다."));
+
+    return RecyclingEduPostResponse.from(post);
+  }
+}

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -2,8 +2,10 @@ package kr.bi.greenmate.recycling_edu_post.service;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
@@ -24,12 +26,10 @@ public class RecyclingEduPostService {
    * 전체 목록 조회
    */
   public List<RecyclingEduPostResponse> getAllPosts() {
-    List<RecyclingEduPost> posts = repository.findAll();
-    return posts.stream()
+    return repository.findAll().stream()
         .map(post -> RecyclingEduPostResponse.from(
             post,
-            objectStorageRepository.getDownloadUrl(post.getImageUrl())
-        ))
+            objectStorageRepository.getDownloadUrl(post.getImageUrl())))
         .toList();
   }
 
@@ -37,11 +37,10 @@ public class RecyclingEduPostService {
    * 단일 조회
    */
   public RecyclingEduPostResponse getPostById(Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("ID는 null일 수 없습니다.");
-    }
     RecyclingEduPost post = repository.findById(id)
-        .orElseThrow(() -> new IllegalArgumentException("해당 분리수거 학습글이 존재하지 않습니다."));
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "해당 분리수거 학습글이 존재하지 않습니다."));
+
     String imageUrl = objectStorageRepository.getDownloadUrl(post.getImageUrl());
     return RecyclingEduPostResponse.from(post, imageUrl);
   }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -1,11 +1,11 @@
 package kr.bi.greenmate.recycling_edu_post.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.recycling_edu_post.domain.RecyclingEduPost;
 import kr.bi.greenmate.recycling_edu_post.dto.RecyclingEduPostResponse;
 import kr.bi.greenmate.recycling_edu_post.repository.RecyclingEduPostRepository;
@@ -19,13 +19,16 @@ import lombok.RequiredArgsConstructor;
 public class RecyclingEduPostService {
 
   private final RecyclingEduPostRepository repository;
+  private final ObjectStorageRepository objectStorageRepository;
 
   /**
    * 전체 목록 조회
    */
   public List<RecyclingEduPostResponse> getAllPosts() {
-    return repository.findAll().stream()
-        .map(RecyclingEduPostResponse::from)
+    List<RecyclingEduPost> posts = repository.findAll();
+
+    return posts.stream()
+        .map(post -> RecyclingEduPostResponse.from(post, objectStorageRepository))
         .toList();
   }
 
@@ -40,6 +43,6 @@ public class RecyclingEduPostService {
     RecyclingEduPost post = repository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("해당 분리수거 학습글이 존재하지 않습니다."));
 
-    return RecyclingEduPostResponse.from(post);
+    return RecyclingEduPostResponse.from(post, objectStorageRepository);
   }
 }


### PR DESCRIPTION
### 개요
- [분리수거 학습 조회 API 추가](https://bi-2025-summer.atlassian.net/browse/TEAM2-37)

### 변경사항
- 분리수거 학습 목록 조회 API
  - GET `/recycling-edu-posts`
- 분리수거 학습 단일 조회 API
  - GET `/recycling-edu-posts/{id}`

#### 참고사항
- 분리수거 학습 데이터 추가
<img width="990" height="235" alt="image" src="https://github.com/user-attachments/assets/048f7be1-0fa1-40b9-b0af-9841f380a746" />

### 리뷰어에게 하고 싶은 말
드디어 첫 API를 짰네요. 근데 이거 이렇게하는거 맞는지 모르겠슴다 😂 