### PR TITLE
TEAM2-13 환경 활동 모집 글 작성 API 구현

### DIFF
--- a/src/main/java/kr/bi/greenmate/common/dto/IdResponse.java
+++ b/src/main/java/kr/bi/greenmate/common/dto/IdResponse.java
@@ -1,0 +1,5 @@
+package kr.bi.greenmate.common.dto;
+
+public record IdResponse(Long id) {
+
+}

--- a/src/main/java/kr/bi/greenmate/common/service/ImageService.java
+++ b/src/main/java/kr/bi/greenmate/common/service/ImageService.java
@@ -1,0 +1,113 @@
+package kr.bi.greenmate.common.service;
+
+import kr.bi.greenmate.common.repository.ObjectStorageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+  private static final long MAX_IMAGE_BYTES = 1_000_000L; // 1MB (정책대로 10진수 1MB)
+  private static final Set<String> ALLOWED = Set.of("image/jpeg", "image/jpg", "image/png");
+
+  private final ObjectStorageRepository storage;
+
+  /**
+   * 단일 이미지 업로드: 도메인 제외 key 반환 (예: green-team-post/UUID32.jpg)
+   */
+  public String uploadOne(String directory, MultipartFile file) {
+    String dir = normalize(directory);
+    validate(dir, file);
+
+    String ext = pickExt(file.getContentType()); // ".jpg" or ".png"
+    String uuid32 = UUID.randomUUID().toString().replace("-", "");
+    String key = uuid32 + ext;
+
+    try (InputStream is = file.getInputStream()) {
+      // 저장소가 반환하는 최종 key를 그대로 반환 (경로 조합 중복 제거)
+      return storage.upload(dir, key, is);
+    } catch (IOException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 실패", e);
+    }
+  }
+
+  /**
+   * 다중 이미지 업로드
+   * <p>
+   * - 파일 목록이 비어있으면 빈 리스트를 반환한다. - 파일 개수가 maxCount를 초과하면 예외를 발생시킨다. - 각 파일이 비어있으면 예외를 발생시킨다.
+   */
+  public List<String> uploadMany(String directory, List<MultipartFile> files, int maxCount) {
+    if (files == null || files.isEmpty()) {
+      return Collections.emptyList();
+    }
+    if (files.size() > maxCount) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "이미지는 최대 " + maxCount + "장까지 업로드 가능합니다.");
+    }
+    List<String> results = new ArrayList<>(files.size());
+    for (MultipartFile f : files) {
+      if (f == null || f.isEmpty()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "비어있는 파일이 포함되어 있습니다.");
+      }
+      results.add(uploadOne(directory, f));
+    }
+    return results;
+  }
+
+  /**
+   * 업로드할 이미지의 디렉토리, 파일 존재 여부, 크기, MIME 타입을 검증
+   */
+  private void validate(String directory, MultipartFile file) {
+    if (directory == null || directory.isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "저장 디렉토리가 비어있습니다.");
+    }
+    if (file == null || file.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "파일이 비어있습니다.");
+    }
+    if (file.getSize() > MAX_IMAGE_BYTES) {
+      throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "이미지는 최대 1MB까지 업로드 가능합니다.");
+    }
+    String ct = Optional.ofNullable(file.getContentType()).orElse("").toLowerCase(Locale.ROOT);
+    if (!ALLOWED.contains(ct)) {
+      throw new ResponseStatusException(
+          HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 이미지 형식입니다. jpeg, jpg, png만 지원합니다.");
+    }
+  }
+
+  /**
+   * Content-Type 값을 기반으로 저장할 이미지 파일의 확장자를 결정
+   */
+  private String pickExt(String contentType) {
+    String ct = Optional.ofNullable(contentType).orElse("").toLowerCase(Locale.ROOT);
+    if (ct.contains("png")) {
+      return ".png";
+    }
+    return ".jpg"; // jpeg/jpg 기본
+  }
+
+  /**
+   * 디렉토리 경로의 앞뒤 공백과 마지막 슬래시를 제거하여 일관된 형식으로 반환
+   */
+  private String normalize(String dir) {
+    String d = dir == null ? "" : dir.trim();
+    if (d.isEmpty()) {
+      return d;
+    }
+    return d.endsWith("/") ? d.substring(0, d.length() - 1) : d;
+  }
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -1,0 +1,50 @@
+package kr.bi.greenmate.green_team_post.controller;
+
+import java.net.URI;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import kr.bi.greenmate.common.dto.IdResponse;
+import kr.bi.greenmate.green_team_post.dto.GreenTeamPostCreateRequest;
+import kr.bi.greenmate.green_team_post.service.GreenTeamPostCommandService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/green-team-posts")
+@Tag(name = "환경 활동 모집글 API", description = "환경 활동 모집글 생성 API")
+public class GreenTeamPostController {
+
+  private final GreenTeamPostCommandService service;
+
+  @Operation(summary = "모집글 생성", description = "환경 활동 모집글을 생성합니다.")
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<IdResponse> create(
+      @ModelAttribute @Valid GreenTeamPostCreateRequest request,
+      @AuthenticationPrincipal(expression = "id") Long userId
+  ) {
+    Long id = service.create(userId, request);
+
+    URI location = ServletUriComponentsBuilder
+        .fromCurrentRequest()
+        .path("/{id}")
+        .buildAndExpand(id)
+        .toUri();
+
+    return ResponseEntity
+        .created(location)
+        .body(new IdResponse(id));
+  }
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostCreateRequest.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostCreateRequest.java
@@ -1,0 +1,54 @@
+package kr.bi.greenmate.green_team_post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 환경 활동 모집글 생성 요청 DTO
+ * - multipart/form-data 바인딩(@ModelAttribute) 기준
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class GreenTeamPostCreateRequest {
+
+  @NotBlank
+  @Size(max = 50)
+  private String title;
+
+  @NotBlank
+  @Size(max = 4000)
+  private String content;
+
+  @NotNull
+  private kr.bi.greenmate.green_team_post.domain.LocationType locationType;
+
+  @NotBlank
+  private String locationGeojson; // 프론트에서 전달받은 GeoJSON 그대로 저장
+
+  @NotNull
+  @Min(1)
+  private Integer maxParticipants;
+
+  @NotNull
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  private LocalDateTime eventDate;
+
+  @NotNull
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+  private LocalDateTime deadlineAt;
+
+  @Size(max = 3)
+  private List<MultipartFile> images;
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostImageRepository.java
@@ -1,0 +1,12 @@
+package kr.bi.greenmate.green_team_post.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPostImage;
+
+public interface GreenTeamPostImageRepository extends JpaRepository<GreenTeamPostImage, Long> {
+
+  List<GreenTeamPostImage> findByPostIdOrderByIdAsc(Long postId);
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostRepository.java
@@ -1,0 +1,14 @@
+package kr.bi.greenmate.green_team_post.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
+
+public interface GreenTeamPostRepository extends JpaRepository<GreenTeamPost, Long> {
+
+  @EntityGraph(attributePaths = "images")
+  Optional<GreenTeamPost> findWithImagesById(Long id);
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
@@ -1,0 +1,132 @@
+package kr.bi.greenmate.green_team_post.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import kr.bi.greenmate.common.service.ImageService;
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPostImage;
+import kr.bi.greenmate.green_team_post.dto.GreenTeamPostCreateRequest;
+import kr.bi.greenmate.green_team_post.repository.GreenTeamPostImageRepository;
+import kr.bi.greenmate.green_team_post.repository.GreenTeamPostRepository;
+import kr.bi.greenmate.user.domain.User;
+import kr.bi.greenmate.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GreenTeamPostCommandService {
+
+  private static final String IMAGE_DIR = "green-team-posts";
+  private static final int MAX_IMAGE_COUNT = 3;
+
+  private final GreenTeamPostRepository postRepository;
+  private final GreenTeamPostImageRepository imageRepository;
+  private final UserRepository userRepository;
+  private final ImageService imageService;
+
+  /**
+   * 환경 활동 모집글 생성
+   *
+   * @param userId 작성자 ID
+   * @param req    게시글 생성 요청 DTO
+   * @return 생성된 게시글 ID
+   */
+  @Transactional
+  public Long create(Long userId, GreenTeamPostCreateRequest req) {
+    validateRequest(userId, req);
+
+    User writer = findWriter(userId);
+    GreenTeamPost post = createPost(writer, req);
+    saveImages(post, req.getImages());
+
+    return post.getId();
+  }
+
+  private void validateRequest(Long userId, GreenTeamPostCreateRequest req) {
+    if (userId == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    if (req.getEventDate().isBefore(now)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "활동일은 현재 시점 이후여야 합니다.");
+    }
+
+    if (req.getDeadlineAt().isBefore(now)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "모집 종료일은 현재 시점 이후여야 합니다.");
+    }
+
+    if (req.getDeadlineAt().isAfter(req.getEventDate())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "모집 종료일은 활동일 이전이어야 합니다.");
+    }
+
+    if (req.getMaxParticipants() == null || req.getMaxParticipants() < 1) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "최대 참가 인원은 1명 이상이어야 합니다.");
+    }
+
+    if (req.getImages().size() > MAX_IMAGE_COUNT) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "이미지는 최대 " + MAX_IMAGE_COUNT + "장까지 업로드 가능합니다."
+      );
+    }
+  }
+
+  private User findWriter(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 사용자입니다."));
+  }
+
+  private GreenTeamPost createPost(User writer, GreenTeamPostCreateRequest req) {
+    GreenTeamPost post = GreenTeamPost.builder()
+        .user(writer)
+        .title(req.getTitle())
+        .content(req.getContent())
+        .locationType(req.getLocationType())
+        .locationGeojson(req.getLocationGeojson())
+        .maxParticipants(req.getMaxParticipants())
+        .eventDate(req.getEventDate())
+        .deadlineAt(req.getDeadlineAt())
+        .build();
+
+    return postRepository.save(post);
+  }
+
+  private void saveImages(GreenTeamPost post, List<MultipartFile> images) {
+    if (images == null || images.isEmpty()) {
+      return;
+    }
+
+    try {
+      List<String> keys = imageService.uploadMany(
+          IMAGE_DIR,
+          images,
+          MAX_IMAGE_COUNT
+      );
+
+      List<GreenTeamPostImage> postImages = keys.stream()
+          .map(key -> GreenTeamPostImage.builder()
+              .post(post)
+              .imageUrl(key)
+              .build())
+          .toList();
+
+      imageRepository.saveAll(postImages);
+
+    } catch (ResponseStatusException e) {
+      throw e; // ImageService에서 예외처리
+    } catch (Exception e) {
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          "게시글 이미지 처리 중 오류가 발생했습니다.",
+          e
+      );
+    }
+  }
+}


### PR DESCRIPTION
### 개요
- [환경 활동 모집 글 작성 API 추가](https://bi-2025-summer.atlassian.net/browse/TEAM2-13)

### 변경사항
#### 공통 이미지 서비스 (ImageService)
- 단일/다중 이미지 업로드 기능 구현
- 파일 검증 로직 추가 (최대 1MB 제한, MIME 타입 검증)
- 업로드 시 UUID 기반 Key 생성 및 ObjectStorageRepository 연동

#### 환경 활동 모집글 작성 API
- **DTO**
  - @ModelAttribute 기반 multipart/form-data 요청 바인딩 처리
- **서비스 계층 (GreenTeamPostCommandService)**
  - 모집글 생성 비즈니스 로직 구현
  - 요청 검증 (로그인 여부, 날짜 유효성, 모집 인원, 이미지 개수 제한)
  - 작성자 조회 및 모집글 엔티티 생성
  - 이미지 업로드(ImageService) 연동 후 GreenTeamPostImage 저장
- **컨트롤러 (GreenTeamPostController)**
  - POST /api/v1/green-team-posts 엔드포인트 추가
  - 모집글 생성 처리 및 생성된 ID 반환 (201 Created + Location 헤더)

### 리뷰어에게 하고 싶은 말
- 이미지 업로드와 관련하여 합의되진 않았으나, 우선적으로 image/jpeg, image/jpg, image/png 만 허용하도록 구현했습니다. 
다른 의견이나 추가적인 요구사항이 있다면 피드백 부탁드립니다. 별다른 의견이 없으면 해당 방향으로 진행하고자합니다.
- 유저 관련 로직은 현재 다른 팀원이 구현 중이어서, 임시로 구현해두었습니다. 
해당 작업 완료 시 작성자 조회 및 연동 부분을 실제 구현된 로직에 맞게 수정할 예정입니다.
- 이미지 업로드 로직을 ImageService에 두는 것이 적절한지(이름·위치·범위)에 대해 고민을 ... 했습니다..... 🤔🧐 