### PR TITLE
TEAM2-73 환경 활동 모집 글 작성 API 컴파일 에러 해결

### DIFF
--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -54,7 +54,7 @@ public class GreenTeamPostController {
   ) {
     List<MultipartFile> safeImages = (images == null) ? List.of() : images;
 
-    Long userId = 1L; // 유저 인증 기능 구현 후 삭제
+    Long userId = 1L; // TODO: 유저 인증 기능 구현 후 삭제
     Long id = service.create(userId, data, safeImages);
 
     URI location = ServletUriComponentsBuilder

--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -52,11 +51,10 @@ public class GreenTeamPostController {
       @Valid
       @RequestPart("data") GreenTeamPostCreateRequest data,
       @RequestPart(value = "images", required = false) List<MultipartFile> images
-//      @AuthenticationPrincipal(expression = "id") Long userId
   ) {
     List<MultipartFile> safeImages = (images == null) ? List.of() : images;
 
-    Long userId = 1L; // 개발용 임시값
+    Long userId = 1L; // 유저 인증 기능 구현 후 삭제
     Long id = service.create(userId, data, safeImages);
 
     URI location = ServletUriComponentsBuilder

--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -52,10 +52,11 @@ public class GreenTeamPostController {
       @Valid
       @RequestPart("data") GreenTeamPostCreateRequest data,
       @RequestPart(value = "images", required = false) List<MultipartFile> images
-      @AuthenticationPrincipal(expression = "id") Long userId
+//      @AuthenticationPrincipal(expression = "id") Long userId
   ) {
     List<MultipartFile> safeImages = (images == null) ? List.of() : images;
 
+    Long userId = 1L; // 개발용 임시값
     Long id = service.create(userId, data, safeImages);
 
     URI location = ServletUriComponentsBuilder

--- a/src/main/java/kr/bi/greenmate/user/repository/UserRepository.java
+++ b/src/main/java/kr/bi/greenmate/user/repository/UserRepository.java
@@ -4,6 +4,8 @@ import kr.bi.greenmate.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
+
+  boolean existsByEmail(String email);
+
+  boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
### 개요
- [환경 활동 모집 글 작성 API 컴파일 에러 해결](https://bi-2025-summer.atlassian.net/browse/TEAM2-73)

### 변경사항
- Controller 레벨에서 임시 userId 값을 주입
- 미구현된 유저 인증 주석 처리
- User repository 추가 (#11 코드와 동일)

### 리뷰어에게 하고 싶은 말
- 로컬에서 개발 후 테스트 시 위 위와 같이 임시 처리를 해놓았으나, 해당 부분 인지하지못하고 PR 머지했습니다.
- 앞으로 주의하겠습니다핫...!