### PR TITLE
TEAM2-19 환경 활동 글 단일 조회 API 구현

### DIFF
--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -3,17 +3,20 @@ package kr.bi.greenmate.green_team_post.controller;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.net.URI;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -23,7 +26,9 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import kr.bi.greenmate.common.dto.IdResponse;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostCreateRequest;
+import kr.bi.greenmate.green_team_post.dto.GreenTeamPostDetailResponse;
 import kr.bi.greenmate.green_team_post.service.GreenTeamPostCommandService;
+import kr.bi.greenmate.green_team_post.service.GreenTeamPostQueryService;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +36,8 @@ import kr.bi.greenmate.green_team_post.service.GreenTeamPostCommandService;
 @Tag(name = "환경 활동 모집글 API", description = "환경 활동 모집글 생성 API")
 public class GreenTeamPostController {
 
-  private final GreenTeamPostCommandService service;
+  private final GreenTeamPostCommandService commandService;
+  private final GreenTeamPostQueryService queryService;
 
   @Operation(
       summary = "환경 활동 모집글 생성",
@@ -47,7 +53,7 @@ public class GreenTeamPostController {
       )
   )
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<IdResponse> create(
+  public ResponseEntity<IdResponse> createGreenTeamPost(
       @Valid
       @RequestPart("data") GreenTeamPostCreateRequest data,
       @RequestPart(value = "images", required = false) List<MultipartFile> images
@@ -55,7 +61,7 @@ public class GreenTeamPostController {
     List<MultipartFile> safeImages = (images == null) ? List.of() : images;
 
     Long userId = 1L; // TODO: 유저 인증 기능 구현 후 삭제
-    Long id = service.create(userId, data, safeImages);
+    Long id = commandService.create(userId, data, safeImages);
 
     URI location = ServletUriComponentsBuilder
         .fromCurrentRequest()
@@ -64,5 +70,13 @@ public class GreenTeamPostController {
         .toUri();
 
     return ResponseEntity.created(location).body(new IdResponse(id));
+  }
+
+  @Operation(summary = "환경 활동 단일 모집글 조회", description = "특정 ID의 환경 활동 모집글을 조회합니다.")
+  @GetMapping("/{id}")
+  public ResponseEntity<GreenTeamPostDetailResponse> getGreenTeamPostById(
+      @PathVariable @NotNull @Min(1) Long id
+  ) {
+    return ResponseEntity.ok(queryService.getPostDetail(id));
   }
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -1,5 +1,6 @@
 package kr.bi.greenmate.green_team_post.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -75,6 +76,11 @@ public class GreenTeamPostController {
   @Operation(summary = "환경 활동 단일 모집글 조회", description = "특정 ID의 환경 활동 모집글을 조회합니다.")
   @GetMapping("/{id}")
   public ResponseEntity<GreenTeamPostDetailResponse> getGreenTeamPostById(
+      @Parameter(
+          description = "조회할 환경 활동 모집글 ID (1 이상의 정수)",
+          required = true,
+          example = "1"
+      )
       @PathVariable @NotNull @Min(1) Long id
   ) {
     return ResponseEntity.ok(queryService.getPostDetail(id));

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
@@ -4,17 +4,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
 import kr.bi.greenmate.green_team_post.domain.LocationType;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 @Schema(description = "환경 활동 모집글 상세 응답 DTO")
 public class GreenTeamPostDetailResponse {

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
@@ -1,0 +1,73 @@
+package kr.bi.greenmate.green_team_post.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import kr.bi.greenmate.green_team_post.domain.LocationType;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "환경 활동 모집글 상세 응답 DTO")
+public class GreenTeamPostDetailResponse {
+
+  @Schema(description = "모집글 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "작성자 ID", example = "1")
+  private Long userId;
+
+  @Schema(description = "작성자 닉네임", example = "nickname")
+  private String nickname;
+
+  @Schema(description = "모집글 제목", example = "한강 플로깅 함께해요")
+  private String title;
+
+  @Schema(description = "모집글 본문 내용", example = "함께 한강을 걸으며 쓰레기를 주워요!")
+  private String content;
+
+  @Schema(description = "활동 위치 유형", example = "CIRCLE", allowableValues = {"CIRCLE", "POLYGON"})
+  private LocationType locationType;
+
+  @Schema(description = "GeoJSON 문자열 (활동 위치 좌표)",
+      example = "{\"center\":{\"lat\":36.61,\"lng\":127.28},\"radius\":392.24}")
+  private String locationGeojson;
+
+  @Schema(description = "모집 정원 (최대 참여자 수)", example = "20")
+  private Integer maxParticipants;
+
+  @Schema(description = "현재 참여자 수", example = "5")
+  private Integer participantCount;
+
+  @Schema(description = "좋아요 수", example = "12")
+  private Integer likeCount;
+
+  @Schema(description = "댓글 수", example = "3")
+  private Integer commentCount;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @Schema(description = "활동일", example = "2025-09-01T10:00:00")
+  private LocalDateTime eventDate;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @Schema(description = "신청 마감일", example = "2025-08-30T23:59:59")
+  private LocalDateTime deadlineAt;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @Schema(description = "등록일시", example = "2025-08-01T12:34:56")
+  private LocalDateTime createdAt;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @Schema(description = "수정일시", example = "2025-08-10T08:22:11")
+  private LocalDateTime updatedAt;
+
+  @Schema(description = "첨부 이미지 URL 목록")
+  private List<String> imageUrls;
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostDetailResponse.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
 import kr.bi.greenmate.green_team_post.domain.LocationType;
 
 @Getter
@@ -70,4 +71,25 @@ public class GreenTeamPostDetailResponse {
 
   @Schema(description = "첨부 이미지 URL 목록")
   private List<String> imageUrls;
+
+  public static GreenTeamPostDetailResponse from(GreenTeamPost post, List<String> imageUrls) {
+    return GreenTeamPostDetailResponse.builder()
+        .id(post.getId())
+        .userId(post.getUser().getId())
+        .nickname(post.getUser().getNickname())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .locationType(post.getLocationType())
+        .locationGeojson(post.getLocationGeojson())
+        .maxParticipants(post.getMaxParticipants())
+        .participantCount(post.getParticipantCount())
+        .likeCount(post.getLikeCount())
+        .commentCount(post.getCommentCount())
+        .eventDate(post.getEventDate())
+        .deadlineAt(post.getDeadlineAt())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .imageUrls(imageUrls)
+        .build();
+  }
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
@@ -3,6 +3,7 @@ package kr.bi.greenmate.green_team_post.exception;
 import org.springframework.http.HttpStatus;
 
 public enum GreenTeamPostErrorCode {
+  // 400 ERROR
   GTP_40001("GTP-40001", HttpStatus.BAD_REQUEST, "활동일은 현재 시점 이후여야 합니다."),
   GTP_40002("GTP-40002", HttpStatus.BAD_REQUEST, "모집 종료일은 현재 시점 이후여야 합니다."),
   GTP_40003("GTP-40003", HttpStatus.BAD_REQUEST, "모집 종료일은 활동일 이전이어야 합니다."),
@@ -13,6 +14,9 @@ public enum GreenTeamPostErrorCode {
   AUTH_40101("AUTH-40101", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
   AUTH_40401("AUTH-40401", HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다."),
 
+  GTP_40401("GTP-40401", HttpStatus.NOT_FOUND, "환경 활동 모집글을 찾을 수 없습니다."),
+
+  // 500 ERROR
   GTP_50001("GTP-50001", HttpStatus.INTERNAL_SERVER_ERROR, "위치 데이터 직렬화에 실패했습니다."),
   GENERIC_50001("GENERIC-50001", HttpStatus.INTERNAL_SERVER_ERROR, "서버 처리 중 오류가 발생했습니다."),
   IMG_50001("IMG-50001", HttpStatus.INTERNAL_SERVER_ERROR, "이미지 처리 중 오류가 발생했습니다.");

--- a/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
@@ -12,7 +12,7 @@ public enum GreenTeamPostErrorCode {
   GENERIC_40001("GENERIC-40001", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 
   AUTH_40101("AUTH-40101", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-  AUTH_40401("AUTH-40401", HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다."),
+  AUTH_40401("AUTH-40401", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
   GTP_40401("GTP-40401", HttpStatus.NOT_FOUND, "환경 활동 모집글을 찾을 수 없습니다."),
 

--- a/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostImageRepository.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostImageRepository.java
@@ -1,9 +1,12 @@
 package kr.bi.greenmate.green_team_post.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.bi.greenmate.green_team_post.domain.GreenTeamPostImage;
 
 public interface GreenTeamPostImageRepository extends JpaRepository<GreenTeamPostImage, Long> {
 
+  List<GreenTeamPostImage> findByPostId(Long postId);
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostRepository.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamPostRepository.java
@@ -1,9 +1,17 @@
 package kr.bi.greenmate.green_team_post.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
 
 public interface GreenTeamPostRepository extends JpaRepository<GreenTeamPost, Long> {
 
+  @EntityGraph(attributePaths = "user")
+  @Query("select p from GreenTeamPost p where p.id = :id")
+  Optional<GreenTeamPost> findByIdWithUser(@Param("id") Long id);
 }

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
@@ -33,8 +33,7 @@ public class GreenTeamPostQueryService {
         ));
 
     List<String> imageUrls = imageRepository.findByPostId(id).stream()
-        .map(GreenTeamPostImage::getImageUrl)
-        .map(objectStorageRepository::getDownloadUrl)
+        .map(img -> objectStorageRepository.getDownloadUrl(img.getImageUrl()))
         .toList();
     return GreenTeamPostDetailResponse.from(post, imageUrls);
   }

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
@@ -1,0 +1,59 @@
+package kr.bi.greenmate.green_team_post.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import lombok.RequiredArgsConstructor;
+
+import kr.bi.greenmate.common.repository.ObjectStorageRepository;
+import kr.bi.greenmate.green_team_post.exception.GreenTeamPostErrorCode;
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
+import kr.bi.greenmate.green_team_post.domain.GreenTeamPostImage;
+import kr.bi.greenmate.green_team_post.dto.GreenTeamPostDetailResponse;
+import kr.bi.greenmate.green_team_post.repository.GreenTeamPostImageRepository;
+import kr.bi.greenmate.green_team_post.repository.GreenTeamPostRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GreenTeamPostQueryService {
+
+  private final GreenTeamPostRepository postRepository;
+  private final GreenTeamPostImageRepository imageRepository;
+  private final ObjectStorageRepository objectStorageRepository;
+
+  public GreenTeamPostDetailResponse getPostDetail(Long id) {
+    GreenTeamPost post = postRepository.findByIdWithUser(id)
+        .orElseThrow(() -> new ResponseStatusException(
+            GreenTeamPostErrorCode.GTP_40401.status(),
+            GreenTeamPostErrorCode.GTP_40401.code()
+        ));
+
+    List<String> imageUrls = imageRepository.findByPostId(id).stream()
+        .map(GreenTeamPostImage::getImageUrl)
+        .map(objectStorageRepository::getDownloadUrl)
+        .toList();
+
+    return GreenTeamPostDetailResponse.builder()
+        .id(post.getId())
+        .userId(post.getUser().getId())
+        .nickname(post.getUser().getNickname())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .locationType(post.getLocationType())
+        .locationGeojson(post.getLocationGeojson())
+        .maxParticipants(post.getMaxParticipants())
+        .participantCount(post.getParticipantCount())
+        .likeCount(post.getLikeCount())
+        .commentCount(post.getCommentCount())
+        .eventDate(post.getEventDate())
+        .deadlineAt(post.getDeadlineAt())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .imageUrls(imageUrls)
+        .build();
+  }
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import kr.bi.greenmate.common.repository.ObjectStorageRepository;
 import kr.bi.greenmate.green_team_post.exception.GreenTeamPostErrorCode;
 import kr.bi.greenmate.green_team_post.domain.GreenTeamPost;
-import kr.bi.greenmate.green_team_post.domain.GreenTeamPostImage;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostDetailResponse;
 import kr.bi.greenmate.green_team_post.repository.GreenTeamPostImageRepository;
 import kr.bi.greenmate.green_team_post.repository.GreenTeamPostRepository;

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostQueryService.java
@@ -36,24 +36,6 @@ public class GreenTeamPostQueryService {
         .map(GreenTeamPostImage::getImageUrl)
         .map(objectStorageRepository::getDownloadUrl)
         .toList();
-
-    return GreenTeamPostDetailResponse.builder()
-        .id(post.getId())
-        .userId(post.getUser().getId())
-        .nickname(post.getUser().getNickname())
-        .title(post.getTitle())
-        .content(post.getContent())
-        .locationType(post.getLocationType())
-        .locationGeojson(post.getLocationGeojson())
-        .maxParticipants(post.getMaxParticipants())
-        .participantCount(post.getParticipantCount())
-        .likeCount(post.getLikeCount())
-        .commentCount(post.getCommentCount())
-        .eventDate(post.getEventDate())
-        .deadlineAt(post.getDeadlineAt())
-        .createdAt(post.getCreatedAt())
-        .updatedAt(post.getUpdatedAt())
-        .imageUrls(imageUrls)
-        .build();
+    return GreenTeamPostDetailResponse.from(post, imageUrls);
   }
 }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/controller/RecyclingEduPostController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -34,9 +35,14 @@ public class RecyclingEduPostController {
 
   @Operation(summary = "단일 게시글 조회", description = "특정 분리수거 학습 게시글을 조회합니다.")
   @GetMapping("/{id}")
-  public RecyclingEduPostResponse getPostById(
+  public RecyclingEduPostResponse getRecyclingEduPostById(
+      @Parameter(
+          description = "조회할 분리수가 학습 게시글 ID (1 이상의 정수)",
+          required = true,
+          example = "1"
+      )
       @PathVariable @NotNull @Min(1) Long id
   ) {
-    return service.getPostById(id);
+    return service.getPostDetail(id);
   }
 }

--- a/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
+++ b/src/main/java/kr/bi/greenmate/recycling_edu_post/service/RecyclingEduPostService.java
@@ -35,7 +35,7 @@ public class RecyclingEduPostService {
   /**
    * 단일 조회
    */
-  public RecyclingEduPostResponse getPostById(Long id) {
+  public RecyclingEduPostResponse getPostDetail(Long id) {
     RecyclingEduPost post = repository.findById(id)
         .orElseThrow(() ->
             new ResourceNotFoundException("해당 분리수거 학습글이 존재하지 않습니다."));


### PR DESCRIPTION
### 개요
- [환경 활동 글 단일 조회 API 개발](https://bi-2025-summer.atlassian.net/browse/TEAM2-19)

### 변경사항
- **dto**
  - GreenTeamPostDetailResponse 구현
- repository: GreenTeamPostRepository, GreenTeamPostImageRepository
  - 조회 메서드 구현
- **service: GreenTeamPostQueryService**
  - 모집글 상세 조회 로직(getPostDetail) 구현
- **controller: GreenTeamPostController**
  - GET /api/v1/green-team-posts/{id} 엔트포인트 추가

### 리뷰어에게 하고 싶은 말
- **CommandService와 QueryService로의 서비스 레이어 분리**
  GreenTeamPost 도메인은 생성, 좋아요 토글, 댓글, 상세/목록 조회 등 다양한 기능을 포함하므로  
쓰기/읽기 로직을 명확히 분리하기 위해 CommandService와 QueryService로 나누었습니다.
- **환경 활동 모집글 조회 시 예외 처리**
  환경 활동 모집글을 찾지 못했을 때 404(ResponseStatusException)를 던지도록 구현했습니다.
  다만 현재 GlobalExceptionHandler의 광역 예외 처리로 인하여 500으로 변환되는 이슈가 있습니다.
  본 PR에서는 기능 구현에 집중하고, 해당 이슈는 추후 “예외 처리 공통화” 작업에서 반영하겠습니다.
