### PR TITLE
TEAM2-32 커뮤니티 게시글 상세 조회 API

### DIFF
--- a/src/main/java/kr/bi/greenmate/community/CommunityErrorCode.java
+++ b/src/main/java/kr/bi/greenmate/community/CommunityErrorCode.java
@@ -1,0 +1,17 @@
+package kr.bi.greenmate.community;
+
+import kr.bi.greenmate.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommunityErrorCode implements ErrorCode {
+
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMU-40401", "존재하지 않는 게시글입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/bi/greenmate/community/controller/CommunityController.java
+++ b/src/main/java/kr/bi/greenmate/community/controller/CommunityController.java
@@ -4,7 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import kr.bi.greenmate.auth.dto.CustomUserDetails;
+import kr.bi.greenmate.community.dto.CommunityPostDetailResponse;
 import kr.bi.greenmate.community.dto.CreateCommunityPostRequest;
 import kr.bi.greenmate.community.service.CommunityService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -28,16 +33,25 @@ import java.util.List;
 @Tag(name = "커뮤니티", description = "커뮤니티 글 관련 API")
 public class CommunityController {
 
-  private final CommunityService communityService;
+    private final CommunityService communityService;
 
-  @Operation(summary = "커뮤니티 글 생성", description = "작성된 글(JSON)과 이미지(파일)를 DB에 저장합니다.")
-  @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<Void> posts(
-      @AuthenticationPrincipal CustomUserDetails userDetails,
-      @Valid @RequestPart("data") CreateCommunityPostRequest request,
-      @RequestPart(value = "images", required = false) @Parameter(description = "이미지 파일") List<MultipartFile> imageFiles) {
-    Long userId = userDetails.getId();
-    communityService.createPost(userId, request, imageFiles);
-    return ResponseEntity.status(HttpStatus.CREATED).build();
-  }
+    @Operation(summary = "커뮤니티 글 생성", description = "작성된 글(JSON)과 이미지(파일)를 DB에 저장합니다.")
+    @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> posts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestPart("data") CreateCommunityPostRequest request,
+            @RequestPart(value = "images", required = false) @Parameter(description = "이미지 파일") List<MultipartFile> imageFiles) {
+        Long userId = userDetails.getId();
+        communityService.createPost(userId, request, imageFiles);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(summary = "게시글 상세 조회", description = "커뮤니티 게시글 ID로 상세 정보를 조회합니다.")
+    @GetMapping("/{postId}")
+    public ResponseEntity<CommunityPostDetailResponse> getCommunityPostDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "게시글 ID", required = true, example = "1") @PathVariable @NotNull @Positive Long postId
+    ) {
+        return ResponseEntity.ok(communityService.getPostDetail(userDetails.getId(), postId));
+    }
 }

--- a/src/main/java/kr/bi/greenmate/community/dto/CommunityPostDetailResponse.java
+++ b/src/main/java/kr/bi/greenmate/community/dto/CommunityPostDetailResponse.java
@@ -1,0 +1,75 @@
+package kr.bi.greenmate.community.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.bi.greenmate.community.domain.Community;
+import kr.bi.greenmate.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Schema(description = "게시글 상세 조회 응답 DTO")
+@Getter
+@Builder
+public class CommunityPostDetailResponse {
+
+    @Schema(description = "게시글 id", example = "1")
+    private Long communityId;
+
+    @Schema(description = "제목", example = "길거리 청소왕 인사 올립니다.")
+    private String title;
+
+    @Schema(description = "본문", example = "안녕하세요! 사실 아직 청소왕 꿈나무라서 선생님들께 한수 가르침을 얻고 싶습니다.")
+    private String content;
+
+    @Schema(description = "좋아요 개수", example = "0")
+    private Integer likeCount;
+
+    @Schema(description = "댓글 개수", example = "0")
+    private Integer commentCount;
+
+    @Schema(description = "첨부 이미지 url 목록")
+    private List<String> imageUrls;
+
+    @Schema(description = "생성 일시", example = "2025-08-30 20:15")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2025-08-30 20:15")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "작성자 id", example = "1")
+    private Long writerId;
+
+    @Schema(description = "작성자 닉네임", example = "그린Mate")
+    private String writerNickname;
+
+    @Schema(description = "작성자 프로필 사진 url")
+    private String writerProfileImage;
+
+    @Schema(description = "사용자의 게시글 좋아요 여부", example = "false")
+    private boolean isLiked;
+
+    public static CommunityPostDetailResponse from(Community post, List<String> imageUrls, boolean isLiked) {
+        log.info("starting make CommunityPostDetailResponse");
+        log.info("user id: {}, nickname: {}", post.getUser().getId(), post.getUser().getNickname());
+        User user = post.getUser();
+        log.info("user id: {}, nickname: {}", user.getId(), user.getNickname());
+        return CommunityPostDetailResponse.builder()
+                .communityId(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .likeCount(post.getLikeCount())
+                .commentCount(post.getCommentCount())
+                .imageUrls(imageUrls)
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .writerId(user.getId())
+                .writerNickname(user.getNickname())
+                .writerProfileImage(user.getProfileImageUrl())
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/kr/bi/greenmate/community/repository/CommunityLikeRepository.java
+++ b/src/main/java/kr/bi/greenmate/community/repository/CommunityLikeRepository.java
@@ -1,0 +1,8 @@
+package kr.bi.greenmate.community.repository;
+
+import kr.bi.greenmate.community.domain.CommunityLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Long> {
+    boolean existsByCommunity_IdAndUser_Id(Long communityId, Long userId);
+}

--- a/src/main/java/kr/bi/greenmate/community/repository/CommunityRepository.java
+++ b/src/main/java/kr/bi/greenmate/community/repository/CommunityRepository.java
@@ -1,7 +1,13 @@
 package kr.bi.greenmate.community.repository;
 
 import kr.bi.greenmate.community.domain.Community;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommunityRepository extends JpaRepository<Community, Long> {
+
+    @EntityGraph(attributePaths = {"user", "images"})
+    Optional<Community> findWithDetailsById(Long id);
 }


### PR DESCRIPTION
### 개요
- 게시글 id로 상세 정보를 조회하는 API
- 작성자 정보, 게시글 정보, 사용자의 "좋아요" 여부를 포함합니다.

### 변경사항
- 


### 리뷰어에게 하고 싶은 말
마지막까지 열심히 해봅시다!