### PR TITLE
TEAM2-81 환경 활동 모집 참가 API 구현

### DIFF
--- a/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/controller/GreenTeamPostController.java
@@ -3,7 +3,6 @@ package kr.bi.greenmate.green_team_post.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -36,6 +35,7 @@ import kr.bi.greenmate.auth.dto.CustomUserDetails;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostCreateRequest;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostDetailResponse;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostSummaryResponse;
+import kr.bi.greenmate.green_team_post.dto.GreenTeamPostParticipantResponse;
 import kr.bi.greenmate.green_team_post.dto.GreenTeamPostLikeResponse;
 import kr.bi.greenmate.green_team_post.service.GreenTeamPostCommandService;
 import kr.bi.greenmate.green_team_post.service.GreenTeamPostQueryService;
@@ -87,6 +87,24 @@ public class GreenTeamPostController {
       @PathVariable @NotNull @Min(1) Long id
   ) {
     return ResponseEntity.ok(queryService.getPostDetail(id));
+  }
+
+  @Operation(summary = "환경 활동 모집글 참가 신청", description = "해당 모집글에 참가를 신청합니다.")
+  @PostMapping("/{postId}/participants")
+  public ResponseEntity<GreenTeamPostParticipantResponse> joinPost(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable("postId") Long postId
+  ) {
+    return ResponseEntity.ok(commandService.applyParticipation(postId, userDetails.getId()));
+  }
+
+  @Operation(summary = "환경 활동 모집글 참가 취소", description = "해당 모집글 참가를 취소합니다.")
+  @DeleteMapping("/{postId}/participants")
+  public ResponseEntity<GreenTeamPostParticipantResponse> leavePost(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable("postId") Long postId
+  ) {
+    return ResponseEntity.ok(commandService.cancelParticipation(postId, userDetails.getId()));
   }
 
   @Operation(summary = "모집글 좋아요 생성", description = "해당 모집글에 좋아요를 생성합니다.")

--- a/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/domain/GreenTeamPost.java
@@ -80,6 +80,21 @@ public class GreenTeamPost extends BaseTimeEntity {
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<GreenTeamPostImage> images = new ArrayList<>();
 
+  public void increaseParticipantCount() {
+    if (this.participantCount == null) {
+      this.participantCount = 0;
+    }
+    this.participantCount++;
+  }
+
+  public void decreaseParticipantCount() {
+    if (this.participantCount == null || this.participantCount <= 0) {
+      this.participantCount = 0;
+    } else {
+      this.participantCount--;
+    }
+  }
+
   public void increaseLikeCount() {
     if (this.likeCount == null) {
       this.likeCount = 0;

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostLikeResponse.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostLikeResponse.java
@@ -15,7 +15,7 @@ public class GreenTeamPostLikeResponse {
   @Schema(description = "좋아요 개수", example = "1")
   private long likeCount;
 
-  public static GreenTeamPostLikeResponse of(boolean liked, long likeCount) {
+  public static GreenTeamPostLikeResponse from(boolean liked, long likeCount) {
     return GreenTeamPostLikeResponse.builder()
         .liked(liked)
         .likeCount(likeCount)

--- a/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostParticipantResponse.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/dto/GreenTeamPostParticipantResponse.java
@@ -1,0 +1,24 @@
+package kr.bi.greenmate.green_team_post.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "환경 활동 모집글 참가 응답 DTO")
+public class GreenTeamPostParticipantResponse {
+
+  @Schema(description = "참가 여부", example = "true")
+  private boolean participated;
+
+  @Schema(description = "현재 참가자 수", example = "2")
+  private long participantCount;
+
+  public static GreenTeamPostParticipantResponse from(boolean participated, long participantCount) {
+    return GreenTeamPostParticipantResponse.builder()
+        .participated(participated)
+        .participantCount(participantCount)
+        .build();
+  }
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/exception/GreenTeamPostErrorCode.java
@@ -10,6 +10,8 @@ public enum GreenTeamPostErrorCode {
   GTP_40004("GTP-40004", HttpStatus.BAD_REQUEST, "최대 참가 인원은 1명 이상이어야 합니다."),
   GTP_40005("GTP-40005", HttpStatus.BAD_REQUEST, "이미지는 최대 3장까지 업로드 가능합니다."),
   GTP_40006("GTP-40006", HttpStatus.BAD_REQUEST, "이미지 파일이 유효하지 않습니다."),
+  GTP_40007("GTP-40007", HttpStatus.BAD_REQUEST, "모집 마감일이 지났습니다."),
+  GTP_40008("GTP-40008", HttpStatus.BAD_REQUEST, "모집 정원이 가득 찼습니다."),
   GENERIC_40001("GENERIC-40001", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 
   AUTH_40101("AUTH-40101", HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),

--- a/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamParticipantRepository.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/repository/GreenTeamParticipantRepository.java
@@ -1,0 +1,14 @@
+package kr.bi.greenmate.green_team_post.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.bi.greenmate.green_team_post.domain.GreenTeamParticipant;
+
+public interface GreenTeamParticipantRepository extends JpaRepository<GreenTeamParticipant, Long> {
+
+  boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+  Optional<GreenTeamParticipant> findByPostIdAndUserId(Long postId, Long userId);
+}

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
@@ -162,7 +162,7 @@ public class GreenTeamPostCommandService {
     User user = findWriter(userId);
 
     if (likeRepository.existsByPostIdAndUserId(postId, userId)) {
-      return GreenTeamPostLikeResponse.of(true, post.getLikeCount());
+      return GreenTeamPostLikeResponse.from(true, post.getLikeCount());
     }
 
     likeRepository.save(
@@ -173,7 +173,7 @@ public class GreenTeamPostCommandService {
     );
     post.increaseLikeCount();
 
-    return GreenTeamPostLikeResponse.of(true, post.getLikeCount());
+    return GreenTeamPostLikeResponse.from(true, post.getLikeCount());
   }
 
   /**
@@ -194,7 +194,7 @@ public class GreenTeamPostCommandService {
           post.decreaseLikeCount();
         });
 
-    return GreenTeamPostLikeResponse.of(false, post.getLikeCount());
+    return GreenTeamPostLikeResponse.from(false, post.getLikeCount());
   }
 
   private GreenTeamPost findPostById(Long postId) {

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
@@ -65,7 +65,7 @@ public class GreenTeamPostCommandService {
       );
     }
 
-    User writer = findWriter(userId);
+    User writer = findUserById(userId);
     GreenTeamPost post = createPost(writer, request);
 
     // 이미지가 없을 경우 조기종료
@@ -96,7 +96,7 @@ public class GreenTeamPostCommandService {
   @Transactional
   public GreenTeamPostParticipantResponse applyParticipation(Long postId, Long userId) {
     GreenTeamPost post = findPostById(postId);
-    User user = findWriter(userId);
+    User user = findUserById(userId);
 
     if (participantRepository.existsByPostIdAndUserId(postId, userId)) {
       return GreenTeamPostParticipantResponse.from(true, post.getParticipantCount());
@@ -159,7 +159,7 @@ public class GreenTeamPostCommandService {
   @Transactional
   public GreenTeamPostLikeResponse addLike(Long postId, Long userId) {
     GreenTeamPost post = findPostById(postId);
-    User user = findWriter(userId);
+    User user = findUserById(userId);
 
     if (likeRepository.existsByPostIdAndUserId(postId, userId)) {
       return GreenTeamPostLikeResponse.from(true, post.getLikeCount());
@@ -205,7 +205,7 @@ public class GreenTeamPostCommandService {
         ));
   }
 
-  private User findWriter(Long userId) {
+  private User findUserById(Long userId) {
     return userRepository.findById(userId)
         .orElseThrow(() -> new ResponseStatusException(
             GreenTeamPostErrorCode.AUTH_40401.status(),

--- a/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
+++ b/src/main/java/kr/bi/greenmate/green_team_post/service/GreenTeamPostCommandService.java
@@ -96,7 +96,6 @@ public class GreenTeamPostCommandService {
   @Transactional
   public GreenTeamPostParticipantResponse applyParticipation(Long postId, Long userId) {
     GreenTeamPost post = findPostById(postId);
-    User user = findUserById(userId);
 
     if (participantRepository.existsByPostIdAndUserId(postId, userId)) {
       return GreenTeamPostParticipantResponse.from(true, post.getParticipantCount());
@@ -117,6 +116,7 @@ public class GreenTeamPostCommandService {
     }
 
     // 참가자 저장
+    User user = findUserById(userId);
     participantRepository.save(
         GreenTeamParticipant.builder()
             .post(post)


### PR DESCRIPTION
### 개요
- [환경 활동 모집 참가 API](https://bi-2025-summer.atlassian.net/browse/TEAM2-81)

### 변경사항
- **dto**
  - GreenTeamPostParticipantResponse 구현 (참가 여부, 현재 참가자 수 응답)
- **repository: GreenTeamParticipantRepository**
  - 참가 조회/삭제 메서드 구현 (`existsByPostIdAndUserId`, `findByPostIdAndUserId`)
- **service: GreenTeamPostCommandService**
  - 참가 신청/취소 로직 (`applyParticipation`, `cancelParticipation`) 구현
  - participantCount 증감 로직 엔티티 메서드로 캡슐화 적용
  - 모집 마감일·정원 제한 검증 및 분산락 키 분리 적용
- **controller: GreenTeamPostController**
  - POST /api/v1/green-team-posts/{postId}/participants 엔드포인트 추가
  - DELETE /api/v1/green-team-posts/{postId}/participants 엔드포인트 추가

### 리뷰어에게 하고 싶은 말
예외처리 공통화 반영 작업은 지라파서 진행하겠습니닷